### PR TITLE
Fix quiz answer updates when navigating

### DIFF
--- a/components/quiz/QuizTaker.jsx
+++ b/components/quiz/QuizTaker.jsx
@@ -60,7 +60,8 @@ export function QuizTaker({ quiz }) {
       timeSpent: questionTimeSpent,
     };
 
-    const newAnswers = [...answers, userAnswer];
+    const newAnswers = [...answers];
+    newAnswers[currentQuestion] = userAnswer;
     setAnswers(newAnswers);
 
     if (currentQuestion < quiz.questions.length - 1) {


### PR DESCRIPTION
## Summary
- ensure existing answers are replaced rather than appended when navigating between questions

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685324bdb8f0832999137631827f6c45