### PR TITLE
Fix client build error by moving OpenAI call to API route

### DIFF
--- a/app/api/generate-quiz/route.js
+++ b/app/api/generate-quiz/route.js
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { generateQuiz } from '@/lib/services/openai';
+
+export async function POST(req) {
+  try {
+    const data = await req.json();
+    const { content, subject, difficulty, numberOfQuestions } = data;
+
+    if (!content || !subject || !difficulty || !numberOfQuestions) {
+      return NextResponse.json(
+        { error: 'Missing required fields' },
+        { status: 400 }
+      );
+    }
+
+    const questions = await generateQuiz({
+      content,
+      subject,
+      difficulty,
+      numberOfQuestions,
+    });
+
+    return NextResponse.json({ questions });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error.message || 'Failed to generate quiz' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/quiz/QuizCreator.jsx
+++ b/components/quiz/QuizCreator.jsx
@@ -11,7 +11,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Progress } from '@/components/ui/progress';
-import { generateQuiz } from '@/lib/services/openai';
 import { saveQuiz } from '@/lib/services/quiz';
 import { Loader2, Upload, Brain, Sparkles } from 'lucide-react';
 
@@ -70,13 +69,25 @@ export function QuizCreator() {
     const progressInterval = simulateProgress();
 
     try {
-      // Generate quiz using OpenAI
-      const questions = await generateQuiz({
-        content,
-        subject,
-        difficulty,
-        numberOfQuestions,
+      // Generate quiz using server-side API
+      const res = await fetch('/api/generate-quiz', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          content,
+          subject,
+          difficulty,
+          numberOfQuestions,
+        })
       });
+
+      if (!res.ok) {
+        throw new Error('Failed to generate quiz');
+      }
+
+      const { questions } = await res.json();
 
       setProgress(95);
 


### PR DESCRIPTION
## Summary
- move quiz generation to new server API route
- update `QuizCreator` component to call the API

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532b3482c083298375c6a60ba9242c