### PR TITLE
Fix notes uploader dialog control

### DIFF
--- a/app/notes/page.jsx
+++ b/app/notes/page.jsx
@@ -8,7 +8,6 @@ import { NotesUploader } from '@/components/notes/NotesUploader';
 import { NotesCard } from '@/components/notes/NotesCard';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
 import { getUserLectureNotes, deleteLectureNote } from '@/lib/services/quiz';
 import { FileText, Upload, Plus, RefreshCw } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
@@ -191,9 +190,9 @@ export default function NotesPage() {
 
       <NotesUploader
         open={isDialogOpen}
-        setOpen={setIsDialogOpen}
+        onOpenChange={setIsDialogOpen}
         onSuccess={loadNotes}
       />
     </div>
   );
-} 
+}

--- a/app/notes/page.jsx
+++ b/app/notes/page.jsx
@@ -91,12 +91,6 @@ export default function NotesPage() {
     console.log("isDialogOpen after setting:", true);
   };
 
-  const closeDialog = () => {
-    console.log("Closing notes uploader dialog - setting isDialogOpen to false");
-    setIsDialogOpen(false);
-    console.log("isDialogOpen after setting:", false);
-  };
-
   // Debug dialog state changes
   useEffect(() => {
     console.log("Dialog state changed:", isDialogOpen);
@@ -196,8 +190,8 @@ export default function NotesPage() {
       </div>
 
       <NotesUploader
-        isOpen={isDialogOpen}
-        onClose={closeDialog}
+        open={isDialogOpen}
+        setOpen={setIsDialogOpen}
         onSuccess={loadNotes}
       />
     </div>

--- a/components/notes/NotesUploader.jsx
+++ b/components/notes/NotesUploader.jsx
@@ -11,7 +11,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { saveLectureNotes } from '@/lib/services/quiz';
 import { Loader2, Upload, FileText } from 'lucide-react';
 
-export function NotesUploader({ isOpen, onClose, onSuccess }) {
+export function NotesUploader({ open, setOpen, onSuccess }) {
   const [title, setTitle] = useState('');
   const [subject, setSubject] = useState('');
   const [content, setContent] = useState('');
@@ -21,10 +21,10 @@ export function NotesUploader({ isOpen, onClose, onSuccess }) {
   
   // Reset form when dialog opens
   useEffect(() => {
-    if (isOpen) {
+    if (open) {
       resetForm();
     }
-  }, [isOpen]);
+  }, [open]);
 
   const resetForm = () => {
     setTitle('');
@@ -88,9 +88,7 @@ export function NotesUploader({ isOpen, onClose, onSuccess }) {
       if (onSuccess) {
         onSuccess();
       }
-      if (onClose) {
-        onClose();
-      }
+      setOpen(false);
     } catch (error) {
       console.error('Error saving notes:', error);
       setError(error.message || 'Failed to save notes');
@@ -100,7 +98,7 @@ export function NotesUploader({ isOpen, onClose, onSuccess }) {
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose && onClose()}>
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Upload Lecture Notes</DialogTitle>
@@ -181,7 +179,7 @@ export function NotesUploader({ isOpen, onClose, onSuccess }) {
               variant="outline" 
               onClick={() => {
                 resetForm();
-                if (onClose) onClose();
+                setOpen(false);
               }}
               disabled={isUploading}
             >

--- a/components/notes/NotesUploader.jsx
+++ b/components/notes/NotesUploader.jsx
@@ -11,7 +11,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { saveLectureNotes } from '@/lib/services/quiz';
 import { Loader2, Upload, FileText } from 'lucide-react';
 
-export function NotesUploader({ open, setOpen, onSuccess }) {
+export function NotesUploader({ open, onOpenChange, onSuccess }) {
   const [title, setTitle] = useState('');
   const [subject, setSubject] = useState('');
   const [content, setContent] = useState('');
@@ -88,7 +88,7 @@ export function NotesUploader({ open, setOpen, onSuccess }) {
       if (onSuccess) {
         onSuccess();
       }
-      setOpen(false);
+      onOpenChange(false);
     } catch (error) {
       console.error('Error saving notes:', error);
       setError(error.message || 'Failed to save notes');
@@ -98,7 +98,7 @@ export function NotesUploader({ open, setOpen, onSuccess }) {
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Upload Lecture Notes</DialogTitle>
@@ -179,7 +179,7 @@ export function NotesUploader({ open, setOpen, onSuccess }) {
               variant="outline" 
               onClick={() => {
                 resetForm();
-                setOpen(false);
+                onOpenChange(false);
               }}
               disabled={isUploading}
             >


### PR DESCRIPTION
## Summary
- control `NotesUploader` dialog via `open` and `setOpen` props
- update notes page to pass new props

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857330d223483299e9cdfd8b796c6df